### PR TITLE
fix pid is not a number bug

### DIFF
--- a/bin/nodectl.js
+++ b/bin/nodectl.js
@@ -199,7 +199,7 @@ var	stop = exports.stop = function (callback) {
 	
 		if (pid) {
 			try {
-				process.kill(pid);
+				process.kill(parseInt(pid, 10));
 				fs.unlinkSync(tag);
 				console.log('Service killed.');
 			} catch (e) {


### PR DESCRIPTION
执行`tianma-beta stop`时发现抛出这样的错误：

```
pid must be a number
```
